### PR TITLE
Support generators as subjects for `pipe()`

### DIFF
--- a/src/Internal/CallableIteratorWrapper.php
+++ b/src/Internal/CallableIteratorWrapper.php
@@ -17,9 +17,14 @@ namespace LazyLists\Internal;
 /**
  * This class wraps a generator function (a Closure returning a Generator)
  * into an Iterator so that it can be used as a subject for LazyWorker (`pipe()`).
+ *
+ * @implements \Iterator<mixed, mixed>
  */
 class CallableIteratorWrapper implements \Iterator
 {
+    /**
+     * @var \Generator<mixed>|null
+     */
     private ?\Generator $generator = null;
     protected \Closure $originalGeneratorFn;
 
@@ -38,14 +43,16 @@ class CallableIteratorWrapper implements \Iterator
     {
         if (!$this->hasBeenCalledOnce()) {
             $generatorFn = $this->originalGeneratorFn;
-            $this->generator = $generatorFn();
+            /** @var \Generator<mixed> */
+            $generatorObject = $generatorFn();
+            $this->generator = $generatorObject;
         }
     }
 
     public function current(): mixed
     {
         $this->firstCall();
-        return $this->generator->current();
+        return $this->generator?->current() ?? null;
     }
 
     public function next(): void
@@ -53,7 +60,7 @@ class CallableIteratorWrapper implements \Iterator
         if (!$this->hasBeenCalledOnce()) {
             $this->firstCall();
         } else {
-            $this->generator->next();
+            $this->generator?->next();
         }
     }
 

--- a/src/Internal/CallableIteratorWrapper.php
+++ b/src/Internal/CallableIteratorWrapper.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of the camille-hdl/lazy-lists library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Camille Hodoul <camille.hodoul@gmail.com>
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace LazyLists\Internal;
+
+/**
+ * This class wraps a generator function (a Closure returning a Generator)
+ * into an Iterator so that it can be used as a subject for LazyWorker (`pipe()`).
+ */
+class CallableIteratorWrapper implements \Iterator
+{
+    private ?\Generator $generator = null;
+    protected \Closure $originalGeneratorFn;
+
+    /**
+     * @param \Closure(): \Generator<mixed> $generatorFn
+     */
+    public function __construct(\Closure $generatorFn)
+    {
+        $this->originalGeneratorFn = $generatorFn;
+    }
+
+    /**
+     * The Generator is only created on the first call to the generator function
+     */
+    protected function firstCall(): void
+    {
+        if (!$this->hasBeenCalledOnce()) {
+            $generatorFn = $this->originalGeneratorFn;
+            $this->generator = $generatorFn();
+        }
+    }
+
+    public function current(): mixed
+    {
+        $this->firstCall();
+        return $this->generator->current();
+    }
+
+    public function next(): void
+    {
+        if (!$this->hasBeenCalledOnce()) {
+            $this->firstCall();
+        } else {
+            $this->generator->next();
+        }
+    }
+
+    /**
+     * Returns false until the Generator object has been created
+     * by calling the generator function once.
+     */
+    protected function hasBeenCalledOnce(): bool
+    {
+        if ($this->generator) {
+            return true;
+        }
+        return false;
+    }
+
+    public function key(): mixed
+    {
+        return $this->generator?->key() ?? 0;
+    }
+
+    public function valid(): bool
+    {
+        return $this->generator?->valid() ?? true;
+    }
+
+    /**
+     * Generators cannot be rewound.
+     */
+    public function rewind(): void
+    {
+        // NO-OP
+    }
+}

--- a/src/LazyWorker.php
+++ b/src/LazyWorker.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace LazyLists;
 
 use ArrayIterator;
+use LazyLists\Internal\CallableIteratorWrapper;
 
 use function LazyLists\map;
 use function LazyLists\filter;
@@ -75,10 +76,10 @@ class LazyWorker
     protected $newValueCallbacks = [];
 
     /**
-     * @param array<mixed>|\Iterator<mixed> $subject
+     * @param array<mixed>|\Iterator<mixed>|\Closure $subject
      * @param \LazyLists\Transducer\TransducerInterface[] $transducers
      */
-    public function __construct(array|\Iterator $subject, array $transducers)
+    public function __construct(array|\Iterator|\Closure $subject, array $transducers)
     {
         if (\count($transducers) <= 0) {
             throw new \LogicException(
@@ -444,13 +445,17 @@ class LazyWorker
     }
 
     /**
-     * @param  array<mixed>|\Iterator<mixed> $subject
+     * @param  array<mixed>|\Iterator<mixed>|callable $subject
      * @return \Iterator<mixed>
      */
-    protected static function iteratorFromSubject(array|\Iterator $subject)
+    protected static function iteratorFromSubject(array|\Iterator|\Closure $subject)
     {
         if (\is_array($subject)) {
             return new ArrayIterator($subject);
+        }
+        if ($subject instanceof \Closure) {
+            $wrapperSubject = new CallableIteratorWrapper($subject);
+            return $wrapperSubject;
         }
         return $subject;
     }

--- a/src/LazyWorker.php
+++ b/src/LazyWorker.php
@@ -445,7 +445,7 @@ class LazyWorker
     }
 
     /**
-     * @param  array<mixed>|\Iterator<mixed>|callable $subject
+     * @param  array<mixed>|\Iterator<mixed>|\Closure(): \Generator<mixed> $subject
      * @return \Iterator<mixed>
      */
     protected static function iteratorFromSubject(array|\Iterator|\Closure $subject)

--- a/src/pipe.php
+++ b/src/pipe.php
@@ -26,7 +26,7 @@ namespace LazyLists;
  */
 function pipe(\LazyLists\Transducer\TransducerInterface ...$transducers)
 {
-    return function (array|\Iterator $subject) use ($transducers) {
+    return function (array|\Iterator|\Closure $subject) use ($transducers) {
         $LazyWorker = new LazyWorker($subject, $transducers);
         return $LazyWorker();
     };

--- a/tests/PipeTest.php
+++ b/tests/PipeTest.php
@@ -214,4 +214,28 @@ class PipeTest extends TestCase
         );
         $this->assertSame([1, 2, 3], $pipe($list));
     }
+
+    public function testGenerator()
+    {
+        $generator = (function () {
+            $testValues = [
+                "a", "b", "c", "d", "e"
+            ];
+            foreach ($testValues as $v) {
+                yield $v;
+            }
+        });
+        $isVowel = static function ($v) {
+            return \in_array($v, ["a", "e", "i", "o", "u", "y"], true);
+        };
+        $toUpper = static function ($v) {
+            return \mb_strtoupper($v);
+        };
+        $pipe = pipe(
+            filter($isVowel),
+            map($toUpper)
+        );
+        $output = $pipe($generator);
+        $this->assertSame(["A", "E"], $output);
+    }
 }


### PR DESCRIPTION
## Description

Currently, you can't use `pipe()` with a generator subject.  
Due to the differences between Generators and Iterators, I have to wrap the generator function to handle the first call to the generator function, which creates the Generator object.  
Because generators are forward-only, `rewind` is a dummy method.

This changes the type signatures, so that `pipe()` now accepts a `Closure` as a subject (the generator function).  
As far as I'm aware, it is not possible to check if the provided closure is indeed a generator function that yields values, or a normal function, but I might be wrong.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

